### PR TITLE
Make '.gitignore'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /doc/tags
+/plugin/ext/xsize


### PR DESCRIPTION
`/doc/tags` and `/plugin/ext/xsize` is build result of this vim plugin which should not be managed by source control. Better be ignored.

##### References
- https://github.com/rust-lang/rust.vim/pull/2
- [`.gitignore` of nerdtree](https://github.com/scrooloose/nerdtree/blob/master/.gitignore)
- [`.gitignore` of tabular](https://github.com/godlygeek/tabular/blob/master/.gitignore)